### PR TITLE
Rx Queue

### DIFF
--- a/Core/Inc/canardRxQueue.h
+++ b/Core/Inc/canardRxQueue.h
@@ -1,6 +1,5 @@
 #ifndef CANARD_RX_QUEUE_H
 #define CANARD_RX_QUEUE_H
-#define MAX_QUEUE_SIZE 100
 
 #include <canard.h>
 

--- a/Core/Inc/canardRxQueue.h
+++ b/Core/Inc/canardRxQueue.h
@@ -1,7 +1,7 @@
 #ifndef CANARD_RX_QUEUE_H
 #define CANARD_RX_QUEUE_H
+#define MAX_QUEUE_SIZE 100
 
-#include <stdlib.h>
 #include <canard.h>
 
 struct CanardRxQueueItem {
@@ -11,8 +11,21 @@ struct CanardRxQueueItem {
 
 extern struct CanardRxQueueItem* rxQueueHead;
 extern struct CanardRxQueueItem* rxQueueTail;
+extern uint8_t rxQueueSize;
 
-void enqueueRxFrame(CanardCANFrame* rx_frame);
-struct CanardRxQueueItem* dequeueRxFrame();
+typedef enum {
+  RX_ENQUEUE_SUCCESS,
+  RX_ENQUEUE_EMPTYITEM,
+  RX_ENQUEUE_MALLOCFAIL,
+  RX_ENQUEUE_OVERFLOW
+} enqueueRxReturnCode;
+
+struct dequeueRxReturnItem {
+    bool isSuccess;
+    CanardCANFrame frame;
+};
+
+enqueueRxReturnCode enqueueRxFrame(CanardCANFrame* rx_frame);
+struct dequeueRxReturnItem dequeueRxFrame();
 
 #endif

--- a/Core/Inc/canardRxQueue.h
+++ b/Core/Inc/canardRxQueue.h
@@ -8,8 +8,6 @@ struct CanardRxQueueItem {
     CanardCANFrame frame;
 };
 
-extern struct CanardRxQueueItem* rxQueueHead;
-extern struct CanardRxQueueItem* rxQueueTail;
 extern uint8_t rxQueueSize;
 
 typedef enum {

--- a/Core/Inc/canardRxQueue.h
+++ b/Core/Inc/canardRxQueue.h
@@ -1,0 +1,18 @@
+#ifndef CANARD_RX_QUEUE_H
+#define CANARD_RX_QUEUE_H
+
+#include <stdlib.h>
+#include <canard.h>
+
+struct CanardRxQueueItem {
+    struct CanardRxQueueItem* next;
+    CanardCANFrame frame;
+};
+
+extern struct CanardRxQueueItem* rxQueueHead;
+extern struct CanardRxQueueItem* rxQueueTail;
+
+void enqueueRxFrame(CanardCANFrame* rx_frame);
+struct CanardRxQueueItem* dequeueRxFrame();
+
+#endif

--- a/Core/Src/canardRxQueue.c
+++ b/Core/Src/canardRxQueue.c
@@ -1,47 +1,89 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <canard.h>
-#include "canardRxQueue.h"
+  #include <stdlib.h>
+  #include <canard.h>
+  #include "canardRxQueue.h"
 
-struct CanardRxQueueItem* rxQueueHead = NULL;
-struct CanardRxQueueItem* rxQueueTail = NULL;
+  struct CanardRxQueueItem* rxQueueHead = NULL;
+  struct CanardRxQueueItem* rxQueueTail = NULL;
+  uint8_t rxQueueSize = 0;
 
-void enqueueRxFrame(CanardCANFrame* rx_frame) {
+/*
+  Add a CAN frame to the queue
+  Will return EMPTYITEM, MALLOCFAIL, OVERFLOW, or SUCCESS
 
-  // dynamically allocate memory
-  struct CanardRxQueueItem* new = (struct CanardRxQueueItem*)malloc(sizeof(struct CanardRxQueueItem));
+  RX_ENQUEUE_EMPTYITEM: the recieved rx frame is empty
+  RX_ENQUEUE_MALLOCFAIL: memory was not allocated for the rx frame
+  RX_ENQUEUE_OVERFLOW: queue is of max length. the oldest frame is removed (rxQueueHead) and the recieved frame is enqueued
+  RX_ENQUEUE_SUCCESS: rx frame was successfully enqueued with no other consequences
   
-  if (new == NULL) {
-    printf("CanardRxQueueItem memory allocation failed");
-    return;
+*/
+  enqueueRxReturnCode enqueueRxFrame(CanardCANFrame* rx_frame) {
+
+    // recieved frame is empty
+    if (rx_frame == NULL) {
+      return RX_ENQUEUE_EMPTYITEM;
+    }
+
+    bool isOverflow = false; // is true if the queue is max size
+
+    // If the queue is full, remove the oldest frame (rxQueueHead)
+    if (rxQueueSize >= MAX_QUEUE_SIZE) {
+      struct CanardRxQueueItem* oldHead  = rxQueueHead;
+      rxQueueHead = rxQueueHead->next;
+      free(oldHead);
+      isOverflow = true;
+    }
+
+    // dynamically allocate memory
+    struct CanardRxQueueItem* newQueueItem = (struct CanardRxQueueItem*)malloc(sizeof(struct CanardRxQueueItem));
+    
+    // new queue item was not created
+    if (newQueueItem == NULL) {
+      return RX_ENQUEUE_MALLOCFAIL;
+    }
+
+    newQueueItem->next = NULL;
+    newQueueItem->frame = *rx_frame;
+
+    // the queue is not empty
+    if (rxQueueTail) {
+      rxQueueTail->next = newQueueItem;
+    } else { // the queue is empty
+      rxQueueHead = newQueueItem;
+    }
+
+    rxQueueTail = newQueueItem;
+
+    if (isOverflow) {
+      return RX_ENQUEUE_OVERFLOW;
+    }
+
+    rxQueueSize++;
+    return RX_ENQUEUE_SUCCESS;
   }
 
-  new->next = NULL;
-  new->frame = *rx_frame;
 
-  if (rxQueueTail) {
-    rxQueueTail->next = new;
-  } else {
-    rxQueueHead = new;
+  struct dequeueRxReturnItem dequeueRxFrame() {
+
+    struct dequeueRxReturnItem output;
+
+    if (!rxQueueHead) { // queue is empty, return nothing
+      output.isSuccess = false;
+      return output;
+    }
+
+    // queue is not empty
+    struct CanardRxQueueItem* dequeuedItem = rxQueueHead;
+    output.isSuccess = true;
+    output.frame = dequeuedItem->frame;
+    rxQueueHead = rxQueueHead->next;
+
+    if (!rxQueueHead) {
+      rxQueueTail = NULL; // after dequeuing, the queue is empty
+    }
+
+    rxQueueSize--;
+    free(dequeuedItem);
+
+    return output;
   }
-
-  rxQueueTail = new;
-}
-
-
-struct CanardRxQueueItem* dequeueRxFrame() {
-
-  if (!rxQueueHead) {
-    return NULL; // queue is empty
-  }
-
-  struct CanardRxQueueItem* dequeuedItem  = rxQueueHead;
-  rxQueueHead = rxQueueHead->next;
-
-  if (!rxQueueHead) {
-    rxQueueTail = NULL; // after dequeuing, the queue is empty
-  }
-
-  return dequeuedItem;
-}
 

--- a/Core/Src/canardRxQueue.c
+++ b/Core/Src/canardRxQueue.c
@@ -1,9 +1,10 @@
   #include <stdlib.h>
   #include <canard.h>
   #include "canardRxQueue.h"
+  #define MAX_QUEUE_SIZE 100
 
-  struct CanardRxQueueItem* rxQueueHead = NULL;
-  struct CanardRxQueueItem* rxQueueTail = NULL;
+  static struct CanardRxQueueItem* rxQueueHead = NULL;
+  static struct CanardRxQueueItem* rxQueueTail = NULL;
   uint8_t rxQueueSize = 0;
 
 /*

--- a/Core/Src/canardRxQueue.c
+++ b/Core/Src/canardRxQueue.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <canard.h>
+#include "canardRxQueue.h"
+
+struct CanardRxQueueItem* rxQueueHead = NULL;
+struct CanardRxQueueItem* rxQueueTail = NULL;
+
+void enqueueRxFrame(CanardCANFrame* rx_frame) {
+
+  // dynamically allocate memory
+  struct CanardRxQueueItem* new = (struct CanardRxQueueItem*)malloc(sizeof(struct CanardRxQueueItem));
+  
+  if (new == NULL) {
+    printf("CanardRxQueueItem memory allocation failed");
+    return;
+  }
+
+  new->next = NULL;
+  new->frame = *rx_frame;
+
+  if (rxQueueTail) {
+    rxQueueTail->next = new;
+  } else {
+    rxQueueHead = new;
+  }
+
+  rxQueueTail = new;
+}
+
+
+struct CanardRxQueueItem* dequeueRxFrame() {
+
+  if (!rxQueueHead) {
+    return NULL; // queue is empty
+  }
+
+  struct CanardRxQueueItem* dequeuedItem  = rxQueueHead;
+  rxQueueHead = rxQueueHead->next;
+
+  if (!rxQueueHead) {
+    rxQueueTail = NULL; // after dequeuing, the queue is empty
+  }
+
+  return dequeuedItem;
+}
+

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -168,6 +168,7 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan) {
 				break;
 			case RX_ENQUEUE_OVERFLOW:
 				printf("rxQueue is full, oldest frame has been removed");
+				break;
 			case RX_ENQUEUE_SUCCESS:
 				break;
 		}


### PR DESCRIPTION
This PR changes to Rx ISR logic to shorten the interrupt. The ISR callback function HAL_CAN_RxFifo0MsgPendingCallback now adds the received CANFrame into a queue (CanardRxQueue) instead of processing the frame with canardHandleRxFrame immediately. The queue is continuously dequeued in the superloop.

Flow chart can be found here: https://uwarg-docs.atlassian.net/wiki/spaces/ZP/pages/2859827205/Rx+Queue+to+Shorten+ISR

**Why is this Change Needed:** The interrupt is currently very long because the canardHandleRxFrame is long. Additionally, interrupts are processed in LIFO order, so old interrupts can remain unprocessed for a long time. The queue creates FIFO order instead, so the interrupt itself is much shorter because we call canardHandleRxFrame in the superloop and not in the ISR.

**How users can use the code:** Functionally, the code works the same as before this change.

**What tests has been done to prove the code is working:** Code was tested on a server controller with through the pixhawk. The servo received messages and responded as expected.